### PR TITLE
Make JSON output a little easier to read.

### DIFF
--- a/respite/serializers/jsonserializer.py
+++ b/respite/serializers/jsonserializer.py
@@ -10,4 +10,4 @@ class JSONSerializer(Serializer):
     def serialize(self, request):
         data = super(JSONSerializer, self).serialize(request)
 
-        return json.dumps(data, ensure_ascii=False)
+        return json.dumps(data, ensure_ascii=False, indent=4)


### PR DESCRIPTION
Add the indent parameter to json.dumps in jsonserializer. Makes JSON output easier to read.
