### PR TITLE
Adds support for set-serialization

### DIFF
--- a/respite/serializers/base.py
+++ b/respite/serializers/base.py
@@ -166,7 +166,7 @@ class Serializer(object):
             if isinstance(anything, dict):
                 return serialize_dictionary(anything)
 
-            if isinstance(anything, list):
+            if isinstance(anything, (list, set)):
                 return serialize_list(anything)
 
             if isinstance(anything, django.db.models.query.DateQuerySet):


### PR DESCRIPTION
Allows sets to be serialized, fixing 'Respite does not know how to serialize set'.

Potentially we should add support for frozenset.
